### PR TITLE
feat: add `relativeFrom` to `processorOptions`

### DIFF
--- a/index.js
+++ b/index.js
@@ -156,6 +156,7 @@ module.exports = class CSSModules extends Writer {
   load(content, dependency) {
     let options = this.processorOptions({
       from: dependency.toString(),
+      relativeFrom: dependency.toString().substring(this.inputPaths[0].length + 1),
       map: this.sourceMapOptions()
     });
 


### PR DESCRIPTION
This allows plugins to use the project-relative file location.

```ts
plugin('my-plugin', options => (root, result) => {
  console.log(`Absolute path on file system: ${result.opts.from}`);
  console.log(`Relative path to project: ${result.opts.relativeFrom}`);
  // ...
});
```

Alternatively, if an absolute `from` is not required, it might make more sense to use the `relativeFrom` as `from`.