### PR TITLE
Exclude development stuff from Snyk analysis

### DIFF
--- a/.snyk
+++ b/.snyk
@@ -1,0 +1,6 @@
+# Snyk (https://snyk.io) policy file
+version: v1.14.0
+
+exclude:
+  global:
+    - test.js


### PR DESCRIPTION
As we start driving more automation off of Snyk reporting, we want to make sure we're avoiding any false positives that might come from tests or other development-only code.

This PR configures Snyk to ignore such things in its code analysis.